### PR TITLE
fail silent in endpoint class

### DIFF
--- a/Sources/Endpoint/Endpoint.swift
+++ b/Sources/Endpoint/Endpoint.swift
@@ -25,6 +25,7 @@ open class Endpoint<Payload> {
     public let password: String?
     public let body: Data?
     public let dateFormatter: DateFormatter
+    public let failSilently: Bool
     
     /// Encode the `jsonParams` attribute to a JSON `Data` block for use as the HTTP body of a request
     open var jsonBody: Data? {
@@ -87,6 +88,7 @@ open class Endpoint<Payload> {
     ///   - password: Password for Basic HTTP Authorization header (`Authorization: Basic XXXXXXXXXXXXXXXX`)
     ///   - body: Data to be used verbatim as the HTTP body
     ///   - dateFormatter: DateFormatter object to be used during parsing to decode Date/Time objects
+    ///   - failSilently: If true, EndpointController won't log error outputs if loading fails
     public init(serverUrl: URL? = nil,
                 pathPrefix: String,
                 method: EndpointHttpMethod = .get,
@@ -102,7 +104,8 @@ open class Endpoint<Payload> {
                 username: String? = nil,
                 password: String? = nil,
                 body: Data? = nil,
-                dateFormatter: DateFormatter? = nil) {
+                dateFormatter: DateFormatter? = nil,
+                failSilently: Bool = false) {
         self.serverUrl = serverUrl
         self.pathPrefix = pathPrefix
         self.objId = objId
@@ -119,6 +122,7 @@ open class Endpoint<Payload> {
         self.password = password
         self.body = body
         self.dateFormatter = dateFormatter ?? .iso8601Full
+        self.failSilently = failSilently
     }
     
     /// The `parse` method of the `Endpoint` takes the data retrieved from the server (often JSON encoded)

--- a/Sources/Endpoint/Endpoint.swift
+++ b/Sources/Endpoint/Endpoint.swift
@@ -88,7 +88,7 @@ open class Endpoint<Payload> {
     ///   - password: Password for Basic HTTP Authorization header (`Authorization: Basic XXXXXXXXXXXXXXXX`)
     ///   - body: Data to be used verbatim as the HTTP body
     ///   - dateFormatter: DateFormatter object to be used during parsing to decode Date/Time objects
-    ///   - failSilently: If true, EndpointController won't log error outputs if loading fails
+    ///   - failSilently: If true, EndpointController won't log error outputs for this endpoint if loading fails
     public init(serverUrl: URL? = nil,
                 pathPrefix: String,
                 method: EndpointHttpMethod = .get,

--- a/Tests/EndpointTests/CodableEndpointTests.swift
+++ b/Tests/EndpointTests/CodableEndpointTests.swift
@@ -218,7 +218,7 @@ class CodableEndpointTests: XCTestCase {
             EndpointController<EndpointDefaultServerError>(session: fakeUrlSession,
                                                            reachability: FakeReachability())
         
-        XCTAssertFalse(controller.failSilently)
+        XCTAssertFalse(endpoint.failSilently)
         controller.load(endpoint) { result in
             switch result {
             case .success:
@@ -232,7 +232,7 @@ class CodableEndpointTests: XCTestCase {
         let msg = "Network connection error: \(networkErr)"
         FakeLogStorage.shared.assertMessageContains(level: .warning, message: msg,
                                                     file: "EndpointController.swift",
-                                                    function: "process(networkError:)")
+                                                    function: "process(networkError:failSilently:)")
     }
     
     func testNetworkErrorFailsSilently() {
@@ -240,7 +240,7 @@ class CodableEndpointTests: XCTestCase {
         let data = User.sampleJsonData!
         let serverUrl = URL(string: "https://oakcity.io/foo/bar/baz/1")!
         
-        let endpoint = CodableEndpoint<User>(serverUrl: serverUrl, pathPrefix: "")
+        let endpoint = CodableEndpoint<User>(serverUrl: serverUrl, pathPrefix: "", failSilently: true)
         
         let httpHeaders = [
             "Content-Type": "application/json"
@@ -254,10 +254,9 @@ class CodableEndpointTests: XCTestCase {
         let fakeUrlSession = FakeUrlSession(data: data, urlResponse: urlResponse, error: networkErr)
         let controller =
             EndpointController<EndpointDefaultServerError>(session: fakeUrlSession,
-                                                           reachability: FakeReachability(),
-                                                           failSilently: true)
+                                                           reachability: FakeReachability())
         
-        XCTAssertTrue(controller.failSilently)
+        XCTAssertTrue(endpoint.failSilently)
         controller.load(endpoint) { result in
             switch result {
             case .success:
@@ -272,6 +271,6 @@ class CodableEndpointTests: XCTestCase {
         FakeLogStorage.shared.assertMessageDoesNotContain(level: .warning,
                                                           message: msg,
                                                           file: "EndpointController.swift",
-                                                          function: "process(networkError:)")
+                                                          function: "process(networkError:failSilently:)")
     }
 }


### PR DESCRIPTION
The way we are using Callisto... we just want the "Hello" endpoint to fail silently..not the entire `D1Api` so...adding the param to the struct and not the controller.  